### PR TITLE
Bugfixes

### DIFF
--- a/src/glfs-java.c
+++ b/src/glfs-java.c
@@ -17,25 +17,24 @@
 #include <stdlib.h>
 
 int debugLog(int error, const char *path, char* text){
-      FILE *fp;
-      
-   
-      /* open the file */
-      fp = fopen("/tmp/libgfapi-java-io-debug.log", "a");
-      if (fp == NULL) {
-         printf("I couldn't open results.dat for appending.\n");
-         exit(0);
-      }
-   
-      /* write to the file */
-      fprintf(fp, "%d : %s on %s in pid=%d\n", error, text, path, getpid());
-   
-      /* close the file */
-      fclose(fp);
-   
-      int flag = 1;
-      while (flag);
-      return 0;
+    FILE *fp;
+
+    /* open the file */
+    fp = fopen("/tmp/libgfapi-java-io-debug.log", "a");
+    if (fp == NULL) {
+        printf("I couldn't open results.dat for appending.\n");
+        exit(0);
+    }
+
+    /* write to the file */
+    fprintf(fp, "%d : %s on %s in pid=%d\n", error, text, path, getpid());
+
+    /* close the file */
+    fclose(fp);
+
+    int flag = 1;
+    while (flag);
+    return 0;
 }
 
 
@@ -49,7 +48,6 @@ int glfs_java_chmod(glfs_t *glfs, const char *path, unsigned long mode){
 }
 
 unsigned long glfs_java_getmod(glfs_t *glfs, const char *path){
-	
 	struct stat buf;
 	long ret;
 
@@ -62,7 +60,7 @@ unsigned long glfs_java_getmod(glfs_t *glfs, const char *path){
 }
 
 unsigned int glfs_java_getuid(glfs_t *glfs, const char *path){
-	
+
 	struct stat buf;
 	long ret;
 
@@ -75,7 +73,7 @@ unsigned int glfs_java_getuid(glfs_t *glfs, const char *path){
 }
 
 unsigned int glfs_java_getgid(glfs_t *glfs, const char *path){
-	
+
 	struct stat buf;
 	long ret;
 
@@ -88,7 +86,7 @@ unsigned int glfs_java_getgid(glfs_t *glfs, const char *path){
 }
 
 int glfs_java_getblocksize(glfs_t *glfs, const char *path){
-	
+
 	struct stat buf;
 	long ret;
 
@@ -101,7 +99,7 @@ int glfs_java_getblocksize(glfs_t *glfs, const char *path){
 }
 
 long glfs_java_getmtime(glfs_t *glfs, const char *path){
-	
+
 	struct stat buf;
 	long ret;
 
@@ -114,7 +112,7 @@ long glfs_java_getmtime(glfs_t *glfs, const char *path){
 }
 
 long glfs_java_getctime(glfs_t *glfs, const char *path){
-	
+
 	struct stat buf;
 	long ret;
 
@@ -127,7 +125,7 @@ long glfs_java_getctime(glfs_t *glfs, const char *path){
 }
 
 long glfs_java_getatime(glfs_t *glfs, const char *path){
-	
+
 	struct stat buf;
 	long ret;
 
@@ -142,13 +140,13 @@ char* glfs_java_getxattr(glfs_t *glfs, const char *path, const char *name)
 {
 	int size = 1024;
 	char* buf = malloc(size * sizeof(char));
-	
+
 	glfs_lgetxattr (glfs, path, name, buf, size);
-	
+
 	return buf;
 }
 
-long
+off_t
 glfs_java_file_length (glfs_t *glfs, const char *path)
 {
 	struct stat buf;
@@ -169,11 +167,10 @@ glfs_java_file_exists (glfs_t *glfs, const char *path)
 	struct stat buf;
 	int ret;
 	glfs_t *fs;
-	
+
 	fs = glfs;
 
 	ret = glfs_lstat (fs, path, &buf);
-	//if(ret!=0 && errno != ENOENT) debugLog( ret, path, strerror (errno)    );
 	return (ret == 0);
 }
 
@@ -240,26 +237,24 @@ glfs_java_file_createNewFile (glfs_t *glfs, const char *path)
 	return (ret == 0);
 }
 
-long
+off_t
 glfs_java_volume_size(glfs_t *glfs,  const char *path){
-        struct statvfs statvfs;
-	long ret;
-        ret = glfs_statvfs(glfs,path,&statvfs);
-        if (ret < 0) {
-                return -1;
-        }
+    struct statvfs statvfs;
+	long ret = glfs_statvfs(glfs,path,&statvfs);
+    if (ret < 0) {
+        return -1;
+    }
 	return statvfs.f_blocks * statvfs.f_bsize;
 
 }
 
-long
+off_t
 glfs_java_volume_free(glfs_t *glfs,  const char *path){
 	struct statvfs statvfs;
-	long ret;
+	long ret = glfs_statvfs(glfs,path, &statvfs);
         if (ret < 0) {
 		return -1;
 	}
-        ret = glfs_statvfs(glfs,path, &statvfs);
 	return statvfs.f_bfree * statvfs.f_bsize;
 
 }
@@ -294,7 +289,6 @@ glfs_java_file_mkdir (glfs_t *glfs, const char *path)
 	return (ret == 0);
 }
 
-
 glfs_fd_t *
 glfs_java_open_read (glfs_t *glfs, const char *path)
 {
@@ -308,13 +302,11 @@ glfs_java_open_write (glfs_t *glfs, const char *path)
 	return glfs_open (glfs, path, O_LARGEFILE|O_WRONLY);
 }
 
-
 int
 glfs_java_close (glfs_fd_t *glfd)
 {
 	return glfs_close (glfd);
 }
-
 
 bool
 glfs_java_file_renameTo (glfs_t *glfs, const char *src, const char *dst)
@@ -325,28 +317,28 @@ glfs_java_file_renameTo (glfs_t *glfs, const char *src, const char *dst)
 char**
 glfs_java_list_dir (glfs_t *fs, const char *path)
 {
-        char** listing = NULL;
-        unsigned int size = 0;
-        glfs_fd_t *fd = NULL;
-        char buf[512];
-        struct dirent *entry = NULL;
+    char** listing = NULL;
+    unsigned int size = 0;
+    glfs_fd_t *fd = NULL;
+    char buf[512];
+    struct dirent *entry = NULL;
 
-        fd = glfs_opendir (fs, path);
-        if (!fd) {
-            return listing;
-        }
-
-        while (glfs_readdir_r (fd, (struct dirent *)buf, &entry), entry) {
-         /* skip over . and .. entries */
-	 if(strcmp(entry->d_name,".")==0 || strcmp(entry->d_name,"..")==0) continue;
-
-         // one extra for a NULL
-	 listing=realloc(listing, sizeof(char *) * (++size+1));
-         listing[size-1]= (char*) malloc((strlen(entry->d_name) + 1) * sizeof(char));
-         strcpy (listing[size-1], entry->d_name);
-         listing[size] = (char*)NULL;
-        }
-
-        glfs_closedir (fd);
+    fd = glfs_opendir (fs, path);
+    if (!fd) {
         return listing;
+    }
+
+    while (glfs_readdir_r (fd, (struct dirent *)buf, &entry), entry) {
+     /* skip over . and .. entries */
+        if(strcmp(entry->d_name,".")==0 || strcmp(entry->d_name,"..")==0) continue;
+
+     // one extra for a NULL
+        listing=realloc(listing, sizeof(char *) * (++size+1));
+        listing[size-1]= (char*) malloc((strlen(entry->d_name) + 1) * sizeof(char));
+        strcpy (listing[size-1], entry->d_name);
+        listing[size] = (char*)NULL;
+    }
+
+    glfs_closedir (fd);
+    return listing;
 }

--- a/src/glfs-java.h
+++ b/src/glfs-java.h
@@ -19,8 +19,8 @@
 
 typedef void b_array;
 
-long glfs_java_volume_size(glfs_t *glfs,  const char *path);
-long glfs_java_volume_free(glfs_t *glfs,  const char *path);
+off_t glfs_java_volume_size(glfs_t *glfs,  const char *path);
+off_t glfs_java_volume_free(glfs_t *glfs,  const char *path);
 char* glfs_java_getxattr(glfs_t *glfs, const char *path, const char *name);
 int glfs_java_chown(glfs_t *glfs, const char *path, unsigned int uid, unsigned int gid);
 int glfs_java_chmod(glfs_t *glfs, const char *path, unsigned long mode);
@@ -40,12 +40,11 @@ int glfs_init_async(glfs_t *fs);
 
 int glfs_fini (glfs_t *fs);
 int glfs_set_logging (glfs_t *fs, const char *logfile, int loglevel);
-int glfs_set_volfile_server (glfs_t *fs, const char *transport,
-			     const char *host, int port);
+int glfs_set_volfile_server (glfs_t *fs, const char *transport, const char *host, int port);
 int glfs_set_volfile (glfs_t *fs, const char *volfile);
 
 
-long glfs_java_file_length (glfs_t *fs, const char *path);
+off_t glfs_java_file_length (glfs_t *fs, const char *path);
 bool glfs_java_file_exists (glfs_t *fs, const char *path);
 bool glfs_java_file_delete (glfs_t *fs, const char *path);
 bool glfs_java_file_renameTo (glfs_t *glfs, const char *src, const char *dst);
@@ -60,13 +59,10 @@ glfs_fd_t *glfs_java_open_write (glfs_t *fs, const char *filename);
 
 long glfs_java_seek_set (glfs_fd_t *glfd, off_t location);
 long glfs_java_seek_current (glfs_fd_t *glfd, off_t location);
-long glfs_java_seek_end (glfs_fd_t *glfd, long location);
+long glfs_java_seek_end (glfs_fd_t *glfd, off_t location);
 
-//long glfs_java_bbread (glfs_fd_t *glfd, b_array *io_data, size_t size);
 long glfs_java_read (glfs_fd_t *fd, b_array *io_data, size_t size);
 long glfs_java_write (glfs_fd_t *fd, b_array *io_data, size_t size);
-
-
 
 int glfs_java_close (glfs_fd_t *fd);
 

--- a/src/main/java/org/gluster/fs/GlusterClient.java
+++ b/src/main/java/org/gluster/fs/GlusterClient.java
@@ -20,20 +20,20 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 
-import glusterfsio.glfs_javaJNI;
+import glusterfsio.glfs_java;
 
 public class GlusterClient {
-	
+
 	private static String LIB_NAME="libgfapi-java-io";
 	private static String LIB_FILE=GlusterClient.LIB_NAME + ".so";
 	private static File loadedLib = null;
 	private static int CONNECT_WAIT=1*1000;
-	
-	
+
+
 	public static char PATH_SEPARATOR = File.separatorChar;
 
 	private long fs;
-	
+
     static {
     	try{
     		/* try and load the system library */
@@ -48,11 +48,11 @@ public class GlusterClient {
 		    	try {
 		    		File tempFile = new File(System.getProperty("java.io.tmpdir"));
 		    		loadedLib = new File(tempFile + File.separator + LIB_FILE);
-		    		
+
 		    		if(!loadedLib.exists())
 		    			LibUtil.copyFromJar(LIB_FILE,tempFile);
 		    		//loadedLib.deleteOnExit();
-		    		
+
 				} catch (IOException e) {
 					throw new RuntimeException("Error loading native library:" + e);
 				}
@@ -60,11 +60,11 @@ public class GlusterClient {
 	    	}
     	}
     }
-    
-    private String server = null; 
-    private int port = -1; 
+
+    private String server = null;
+    private int port = -1;
     private String transport = null;
-    
+
     public GlusterClient(String server, int port, String transport){
     	this.server = server;
     	this.port = port;
@@ -78,10 +78,10 @@ public class GlusterClient {
     public GlusterClient(){
     	this("localhost",0,"tcp");
     }
-    
+
     public int setLogging(String LogFile, int LogLevel, long handle) {
         int ret;
-        ret = glfs_javaJNI.glfs_set_logging(handle, LogFile, LogLevel);
+        ret = glfs_java.glfs_set_logging(handle, LogFile, LogLevel);
         return ret;
     }
     public String getPid(){
@@ -107,35 +107,35 @@ public class GlusterClient {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
-       
+
        return null;
-        
+
     }
 
 	public GlusterVolume connect(String volumeName) throws IOException {
         int ret=1;
-       
-        fs = glfs_javaJNI.glfs_new(volumeName);
+
+        fs = glfs_java.glfs_new(volumeName);
 
         if (fs == 0) {
         	throw new IOException("Error connecting to gluster volume:" + server + ":" + port + "/" + volumeName);
         }
-       
-       
-            ret = glfs_javaJNI.glfs_set_volfile_server(fs, transport, server, port);
-            
+
+
+            ret = glfs_java.glfs_set_volfile_server(fs, transport, server, port);
+
         if (ret == -1) {
-            glfs_javaJNI.glfs_fini(fs);
+            glfs_java.glfs_fini(fs);
             throw new IOException("Error connecting to gluster volume:" + server + ":" + port + "/" + volumeName);
         }
-        
+
         setLogging("/tmp/libgfapi-java-io-" + volumeName + "-" + getPid() + ".log", 7, fs);
-        ret = glfs_javaJNI.glfs_init(fs);
-        
+        ret = glfs_java.glfs_init(fs);
+
         int i=0;
         for(i=0 ;i<15 && !(ret==-1 || ret==0);i++){
-           
-            ret = glfs_javaJNI.glfs_init_wait(fs);
+
+            ret = glfs_java.glfs_init_wait(fs);
             if(ret==1){
                 try{
                 Thread.sleep(GlusterClient.CONNECT_WAIT);
@@ -144,11 +144,11 @@ public class GlusterClient {
                 }
                 }
         }
-        
+
         if (i == 15)  throw new IOException("Error connecting to gluster volume, tried 15 times..:" + volumeName);
-        
+
         if (ret == -1) {
-            glfs_javaJNI.glfs_fini(fs);
+            glfs_java.glfs_fini(fs);
             throw new IOException("Error connecting to gluster volume:" + server + ":" + port + "/" + volumeName);
         }
 
@@ -156,7 +156,7 @@ public class GlusterClient {
     }
 
 
-    
-    
- 
+
+
+
 }

--- a/src/main/java/org/gluster/fs/GlusterFile.java
+++ b/src/main/java/org/gluster/fs/GlusterFile.java
@@ -18,7 +18,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.ArrayList;
 
-import glusterfsio.glfs_javaJNI;
+import glusterfsio.glfs_java;
 
 
 public class GlusterFile {
@@ -29,7 +29,7 @@ public class GlusterFile {
 	protected GlusterFile(String path, long handle) {
 		this.handle = handle;
 		/* all paths should not have trailing slash.  tolerate + strip it off */
-		
+
 		if(path.length()>1 && path.charAt(path.length()-1)==GlusterClient.PATH_SEPARATOR){
 			this.path = path.substring(0,path.length()-1);
 		}else{
@@ -54,31 +54,31 @@ public class GlusterFile {
 		int index = fullPath.lastIndexOf(GlusterClient.PATH_SEPARATOR);
 		return fullPath.substring(index + 1);
 	}
-	
+
 	public String pathOnly() {
 		int index = path.lastIndexOf(GlusterClient.PATH_SEPARATOR);
 		if(index<1) return Character.toString(GlusterClient.PATH_SEPARATOR);
 		return path.substring(0,index + 1);
 	}
-	
+
 	public String getName() {
-	
+
 		return getName(this.path);
 	}
 
 	public String getPath(){
 		return this.path;
 	}
-	
+
     public String getParent() {
         int index = path.lastIndexOf(GlusterClient.PATH_SEPARATOR);
         return path.substring(0, index);
    }
-    
+
     public GlusterFile getAbsoluteFile() {
         return this;
     }
-    
+
     private static String slashify(String path, boolean isDirectory) {
         String p = path;
         if (GlusterClient.PATH_SEPARATOR != '/')
@@ -89,7 +89,7 @@ public class GlusterFile {
             p = p + "/";
         return p;
     }
-    
+
     public URI toURI() {
         try {
         	String sp = slashify(getPath(), isDirectory());
@@ -138,11 +138,11 @@ public class GlusterFile {
             return null;
         }
 	}
-	
+
 	public String fullPath(String childName){
 		return this.path + GlusterClient.PATH_SEPARATOR + childName;
 	}
-	
+
 	public GlusterFile[] listFiles() {
 		String[] ss = list();
 		if (ss == null)
@@ -154,7 +154,7 @@ public class GlusterFile {
 		}
 		return fs;
 	}
-	
+
 	public GlusterFile[] listFiles(FilenameFilter filter) {
         String ss[] = list();
         if (ss == null) return null;
@@ -164,22 +164,22 @@ public class GlusterFile {
                 files.add(open(fullPath(s)));
         return files.toArray(new GlusterFile[files.size()]);
     }
-	
+
 	public String[] list() {
-		
+
 		if(isFile()) return null;
-		
-		String list[] = glfs_javaJNI.glfs_java_list_dir(handle, this.path + GlusterClient.PATH_SEPARATOR);
+
+		String list[] = glfs_java.glfs_java_list_dir(handle, this.path + GlusterClient.PATH_SEPARATOR);
 		/* API returns null for no elements */
 		if(list==null)
 			list = new String[0];
-		
+
 		for(int i=0;i<list.length;i++){
 			list[i] = getName(list[i]);
 		}
 		return list;
 	}
-	
+
 	public String[] list(FilenameFilter filter) {
         String names[] = list();
         if ((names == null) || (filter == null)) {
@@ -193,7 +193,7 @@ public class GlusterFile {
         }
         return (String[])(v.toArray(new String[v.size()]));
     }
-	
+
 	public boolean delete(boolean recursive) throws IOException{
 	    	if(isDirectory() && recursive){
 		    	String files[] = list();
@@ -203,97 +203,97 @@ public class GlusterFile {
 		    }
 	    	return delete();
 	}
-	
+
 	public String toString() {
 		return path;
 	}
-	
-	
+
+
 	public String getXAttr(String attr) {
-		return  glfs_javaJNI.glfs_java_getxattr(handle, path, attr);
+		return  glfs_java.glfs_java_getxattr(handle, path, attr);
 	}
-	
+
 	public boolean chmod(int mode) {
-		return  glfs_javaJNI.glfs_java_chmod(handle,path,mode)==0;
+		return  glfs_java.glfs_java_chmod(handle,path,mode)==0;
 	}
-	
+
 	public long getMod() {
-		return  glfs_javaJNI.glfs_java_getmod(handle,path);
+		return  glfs_java.glfs_java_getmod(handle,path);
 	}
-	
+
 	public long getUid() {
-		return  glfs_javaJNI.glfs_java_getuid(handle,path);
+		return  glfs_java.glfs_java_getuid(handle,path);
 	}
 
 	public void setUid(long uid){
 		long gid = getUid();
-		chown(uid,gid);		
+		chown(uid,gid);
 	}
-	
+
 	public void setGid(long gid){
 		long uid = getUid();
 		chown(uid,gid);
 	}
-	
+
 	public void chown(long uid, long gid){
-		 glfs_javaJNI.glfs_java_chown(handle,path,uid,gid);
+		 glfs_java.glfs_java_chown(handle,path,uid,gid);
 	}
-	
+
 	public long getGid() {
-		return  glfs_javaJNI.glfs_java_getgid(handle,path);
+		return  glfs_java.glfs_java_getgid(handle,path);
 	}
 
 	public long getAtime() {
-		return  glfs_javaJNI.glfs_java_getatime(handle,path);
+		return  glfs_java.glfs_java_getatime(handle,path);
 	}
-	
+
 	public long getMtime() {
-		return  glfs_javaJNI.glfs_java_getmtime(handle,path);
+		return  glfs_java.glfs_java_getmtime(handle,path);
 	}
 
 	public long getCtime() {
-		return  glfs_javaJNI.glfs_java_getctime(handle,path);
+		return  glfs_java.glfs_java_getctime(handle,path);
 	}
-	
+
 	public int getBlockSize() {
-		return  glfs_javaJNI.glfs_java_getblocksize(handle,path);
+		return  glfs_java.glfs_java_getblocksize(handle,path);
 	}
-	
+
 	public boolean renameTo(String dstpath) {
 		if(dstpath.charAt(0)==GlusterClient.PATH_SEPARATOR){
-			return glfs_javaJNI.glfs_java_file_renameTo(handle, path, dstpath);
+			return glfs_java.glfs_java_file_renameTo(handle, path, dstpath);
 		}
 		String pathBase = pathOnly();
-		return glfs_javaJNI.glfs_java_file_renameTo(handle, path, pathBase + dstpath);
-		
+		return glfs_java.glfs_java_file_renameTo(handle, path, pathBase + dstpath);
+
 	}
 
 	public long length() {
-		return glfs_javaJNI.glfs_java_file_length(handle, path);
+		return glfs_java.glfs_java_file_length(handle, path);
 	}
 
 	public boolean exists() {
-		return glfs_javaJNI.glfs_java_file_exists(handle, path);
+		return glfs_java.glfs_java_file_exists(handle, path);
 	}
 
 	public boolean createNewFile() {
-		return glfs_javaJNI.glfs_java_file_createNewFile(handle, path);
+		return glfs_java.glfs_java_file_createNewFile(handle, path);
 	}
 
 	public boolean mkdir() {
-		return glfs_javaJNI.glfs_java_file_mkdir(handle, path);
+		return glfs_java.glfs_java_file_mkdir(handle, path);
 	}
 
 	public boolean isDirectory() {
-		return glfs_javaJNI.glfs_java_file_isDirectory(handle, path);
+		return glfs_java.glfs_java_file_isDirectory(handle, path);
 	}
 
 	public boolean isFile() {
-		return glfs_javaJNI.glfs_java_file_isFile(handle, path);
+		return glfs_java.glfs_java_file_isFile(handle, path);
 	}
-	
+
 	public boolean delete() {
-		return glfs_javaJNI.glfs_java_file_delete(handle, path);
+		return glfs_java.glfs_java_file_delete(handle, path);
 	}
 
 	public boolean renameTo(GlusterFile dst) {

--- a/src/main/java/org/gluster/fs/GlusterInputStream.java
+++ b/src/main/java/org/gluster/fs/GlusterInputStream.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
-import glusterfsio.glfs_javaJNI;
+import glusterfsio.glfs_java;
 
 public class GlusterInputStream extends InputStream implements IGlusterInputStream {
     private long fd;
@@ -22,7 +22,7 @@ public class GlusterInputStream extends InputStream implements IGlusterInputStre
 
     /* user should never directly instantiate */
     protected GlusterInputStream(String file, long handle) throws IOException {
-        fd = glfs_javaJNI.glfs_java_open_read(handle, file);
+        fd = glfs_java.glfs_java_open_read(handle, file);
         if (fd == 0) {
             throw new IOException();
         }
@@ -30,18 +30,18 @@ public class GlusterInputStream extends InputStream implements IGlusterInputStre
 
     public boolean seek(long location){
         /* need to error if out of bounds. not sure how its handled lower */
-        glfs_javaJNI.glfs_java_seek_set(fd, location);
+        glfs_java.glfs_java_seek_set(fd, location);
 
         return true;
     }
 
     public long offset(){
-        return glfs_javaJNI.glfs_java_seek_set(fd, 0);
+        return glfs_java.glfs_java_seek_set(fd, 0);
     }
 
-    public int read(ByteBuffer buf, int size){ 
-      return glfs_javaJNI.glfs_java_read(fd, buf, size); 
-    }   
+    public int read(ByteBuffer buf, int size){
+      return glfs_java.glfs_java_read(fd, buf, size);
+    }
 
     public int read(byte[] out, int offset, int length) {
         if (length == 0) {
@@ -54,6 +54,7 @@ public class GlusterInputStream extends InputStream implements IGlusterInputStre
             } else {
                 buffer.get(out, offset, Math.min(length, read));
             }
+            LibUtil.trySilentlyReleaseDirectByteBuffer(buffer);
             return read;
         }
     }
@@ -69,10 +70,10 @@ public class GlusterInputStream extends InputStream implements IGlusterInputStre
     public void close() throws IOException{
             if (fd != 0 && !closing) {
                 closing = true;
-                glfs_javaJNI.glfs_java_close(fd);
+                glfs_java.glfs_java_close(fd);
                 fd = 0;
             }
-     
+
     }
 
     protected void finalize(){

--- a/src/main/java/org/gluster/fs/GlusterOutputStream.java
+++ b/src/main/java/org/gluster/fs/GlusterOutputStream.java
@@ -14,19 +14,19 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
-import glusterfsio.glfs_javaJNI;
+import glusterfsio.glfs_java;
 
 public class GlusterOutputStream extends OutputStream implements IGlusterOutputStream {
-    private long fd;
+    protected long fd;
     protected static final int BUFFER_SIZE = 1024 * 512;
     protected ByteBuffer buf;
 
     protected GlusterOutputStream(String path, long handle) throws IOException {
-        fd = glfs_javaJNI.glfs_java_open_write(handle, path);
+        fd = glfs_java.glfs_java_open_write(handle, path);
         if (fd == 0) {
-            glfs_javaJNI.glfs_java_file_createNewFile(handle, path);
+            glfs_java.glfs_java_file_createNewFile(handle, path);
 
-            fd = glfs_javaJNI.glfs_java_open_write(handle, path);
+            fd = glfs_java.glfs_java_open_write(handle, path);
             if (fd == 0)
                 throw new IOException("Error opening io stream.");
         }
@@ -39,11 +39,11 @@ public class GlusterOutputStream extends OutputStream implements IGlusterOutputS
             flush();
         } catch (IOException e) {
         }
-        glfs_javaJNI.glfs_java_seek_set(fd, position);
+        glfs_java.glfs_java_seek_set(fd, position);
     }
 
     public void flush() throws IOException{
-        glfs_javaJNI.glfs_java_write(fd, buf, buf.position());
+        glfs_java.glfs_java_write(fd, buf, buf.position());
         buf.rewind();
     }
 
@@ -52,7 +52,7 @@ public class GlusterOutputStream extends OutputStream implements IGlusterOutputS
             write(b[i]);
         }
     }
-    
+
     public synchronized void write(int b) throws IOException{
         if (buf.position()+1 >= buf.capacity()) {
             flush();
@@ -60,7 +60,7 @@ public class GlusterOutputStream extends OutputStream implements IGlusterOutputS
         buf.put((byte) b);
     }
 
-    
+
     public void close(){
         if (fd != 0) {
             try {
@@ -68,8 +68,9 @@ public class GlusterOutputStream extends OutputStream implements IGlusterOutputS
             } catch (IOException e) {
 
             }finally{
-                glfs_javaJNI.glfs_java_close(fd);
-                fd = 0;                
+                LibUtil.trySilentlyReleaseDirectByteBuffer(buf);
+                glfs_java.glfs_java_close(fd);
+                fd = 0;
             }
 
         }

--- a/src/main/java/org/gluster/fs/GlusterVolume.java
+++ b/src/main/java/org/gluster/fs/GlusterVolume.java
@@ -18,52 +18,52 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
-import glusterfsio.glfs_javaJNI;
+import glusterfsio.glfs_java;
 
 public class GlusterVolume{
-	
+
 
 
 	private String name;
 	private long handle;
-	
+
 	public GlusterVolume(String name, long handle){
 		this.name = name;
 		this.handle = handle;
-		
+
 	}
 
 
-	
+
 	public GlusterFile open(String path){
-		
+
 		if(path==null) return null;
-		
+
 		return new GlusterFile(path,handle);
-		
-		
+
+
 	}
-	
+
 
 
 	public String getName() {
 		return this.name;
 	}
-	
+
 	public long getFree(){
-		return glfs_javaJNI.glfs_java_volume_free(handle,"/");
+		return glfs_java.glfs_java_volume_free(handle,"/");
 	}
-	
+
 	public long getSize(){
-		return glfs_javaJNI.glfs_java_volume_size(handle,"/");
+		return glfs_java.glfs_java_volume_size(handle,"/");
 	}
-	
+
 	public void close(){
-	    glfs_javaJNI.glfs_fini(this.handle);
+	    glfs_java.glfs_fini(this.handle);
 	}
-	
+
 	public void finalize(){
 	        close();
 	}
-	   
+
 }

--- a/src/main/java/org/gluster/fs/LibUtil.java
+++ b/src/main/java/org/gluster/fs/LibUtil.java
@@ -17,40 +17,66 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
 
 public class LibUtil {
-	
-	public static String PATH_SEP = Character.toString(File.separatorChar);
-	public static File copyFromJar(String path, File dst) throws IOException{
-		
-		if(!path.startsWith(PATH_SEP)) {
-			path = PATH_SEP + path;
-		}
-		
-		InputStream stream = LibUtil.class.getResourceAsStream(path);
-	    if (stream == null) {
-	        throw new IOException(path + " not found in jar.");
-	    }
-	    OutputStream resStreamOut = null;
-	    int readBytes;
-	    
-	    String[] split = path.split("/");
-	    String fileName= split.length==0? path : split[split.length-1];
-	    File result = null;
-	    byte[] buffer = new byte[4096];
-	    try {
-	    	result = new File(dst, fileName);
-	        resStreamOut = new FileOutputStream(result);
-	        while ((readBytes = stream.read(buffer)) > 0) {
-	            resStreamOut.write(buffer, 0, readBytes);
-	        }
-	    } catch (IOException e1) {
-	        e1.printStackTrace();
-	    } finally {
-	        stream.close();
-	        resStreamOut.close();
-	    }
-	    return result;
-	}
 
+    public static String PATH_SEP = Character.toString(File.separatorChar);
+    public static File copyFromJar(String path, File dst) throws IOException{
+
+        if(!path.startsWith(PATH_SEP)) {
+            path = PATH_SEP + path;
+        }
+
+        InputStream stream = LibUtil.class.getResourceAsStream(path);
+        if (stream == null) {
+            throw new IOException(path + " not found in jar.");
+        }
+        OutputStream resStreamOut = null;
+        int readBytes;
+
+        String[] split = path.split("/");
+        String fileName= split.length==0? path : split[split.length-1];
+        File result = null;
+        byte[] buffer = new byte[4096];
+        try {
+            result = new File(dst, fileName);
+            resStreamOut = new FileOutputStream(result);
+            while ((readBytes = stream.read(buffer)) > 0) {
+                resStreamOut.write(buffer, 0, readBytes);
+            }
+        } catch (IOException e1) {
+            e1.printStackTrace();
+        } finally {
+            stream.close();
+            resStreamOut.close();
+        }
+        return result;
+    }
+
+    /**
+     * Attempt to clean direct memory reserved by a java.nio.DirectByteBuffer.
+     * This assumes we are dealing with the Sun implementation that relies on a phantom references cleanup based sun.misc.Cleaner.
+     * If this is not the case (or the buffer is not even a DirectByteBuffer), this method will silently ignore it and to nothing.
+     * As all this is private or package private we hack around using reflection. It's the only way to free direct memory without triggering a gc.
+     */
+    public static void trySilentlyReleaseDirectByteBuffer(ByteBuffer buffer) {
+        try {
+            Method cleanerMethod = buffer.getClass().getMethod("cleaner");
+            cleanerMethod.setAccessible(true);
+            Object cleaner = cleanerMethod.invoke(buffer);
+            Method cleanMethod = cleaner.getClass().getMethod("clean");
+            cleanMethod.setAccessible(true);
+            cleanMethod.invoke(cleaner);
+        } catch (IllegalAccessException e) {
+            // ignore
+        } catch (InvocationTargetException e) {
+            // ignore
+        } catch (NoSuchMethodException e) {
+            // ignore
+        }
+
+    }
 }


### PR DESCRIPTION
- attempt to clean direct memory reserved by a java.nio.DirectByteBuffer.
- ret var. in glfs_java_volume_free function was uninitialized, so randomly could return -1
- swig generates glfs_java_file_length as a int function, so it does not work for files >= 2GB
- use glusterfsio.glfs_java wrapper for java classes, instead of directly glusterfsio.glfs_javaJNI which is internal non-public class.
