### PR TITLE
GlusterOutputStream.java WRITE PERFORMANCE IMPROVEMENT 

### DIFF
--- a/src/main/java/org/gluster/fs/GlusterOutputStream.java
+++ b/src/main/java/org/gluster/fs/GlusterOutputStream.java
@@ -18,7 +18,7 @@ import glusterfsio.glfs_java;
 
 public class GlusterOutputStream extends OutputStream implements IGlusterOutputStream {
     protected long fd;
-    protected static final int BUFFER_SIZE = 1024 * 512;
+    protected static final int BUFFER_SIZE = 512 * 1024;
     protected ByteBuffer buf;
 
     protected GlusterOutputStream(String path, long handle) throws IOException {
@@ -47,10 +47,74 @@ public class GlusterOutputStream extends OutputStream implements IGlusterOutputS
         buf.rewind();
     }
 
+    /** 
+     * Write data using direct allocated ByteBuffer to avoid data copy.  
+     * ByteBuffer must with allocated with ByteBuffer.allocateDirect(size).
+     *
+     * @param buffer containing data to be written into output stream.
+     *
+     */
+    public synchronized void write(ByteBuffer buffer) throws IOException {
+      glfs_java.glfs_java_write(fd, buffer, buffer.position());
+      buffer.rewind();
+    }
+
+    /**
+     * Original implementation copied the given byte array to the buf one
+     * byte at a time, which was extremely slow.  This version segments the
+     * given byte array into segements that fit within the capacity of buf,
+     * and then copy and send those segments, substantially increasing 
+     * performance.
+     *
+     */
     public synchronized void write(byte b[], int off, int len) throws IOException{
+      int segmentLength = buf.capacity();
+      int segments = (len / segmentLength);
+
+      //If the given buffer is less than one segment size, then just write 
+      //the buffer as a segement.
+      if( segments == 0 )
+      {
+        writeSegment(b, off, len);
+      }
+      else
+      {
+        //Check if we have any bytes hanging off our segment boundary,
+        //if so, send one additional non-full segment.
+        if( (len % segmentLength) != 0 )
+        {
+          segments++;
+        }
+        for(int i = 0; i < segments; i++)
+        {
+          if( ((i * segmentLength) + segmentLength) < len )
+          {
+            writeSegment(b, (off + (i * segmentLength)), segmentLength);
+          }
+          else
+          {
+            int remaining = (len - (i * segmentLength));
+            writeSegment(b, (off + (i * segmentLength)), remaining);
+          }
+        }
+      }
+      /* Old implementation is to slow for large byte arrays.
         for (int i = off; i < len; i++) {
             write(b[i]);
         }
+      */
+    }
+
+    private synchronized void writeSegment(byte b[], int off, int len) throws IOException
+    {
+      if( len > buf.capacity() ) {
+        throw new IOException("segment length must not be greater than " + 
+            "buf.capacity() [" + buf.capacity() + " bytes].");
+      }
+      if( (buf.position() + len) > buf.capacity() ) {
+        flush();
+      }
+      buf.put(b, off, len);
     }
 
     public synchronized void write(int b) throws IOException{


### PR DESCRIPTION
The write(byte[], int, int) method now segments the given byte array into a segment size compatible with the backing buffer, and then does a single put of one segment into the backing buffer before making the native call.  The old implementation put the bytes of the given buffer into the backing buffer ONE byte at a time which is extremely slow for large buffers.  Also added a write(ByteBuffer) method for a NO copy option for writing data directly to the native library.
